### PR TITLE
Filter out undefined styles

### DIFF
--- a/code.js
+++ b/code.js
@@ -144,6 +144,8 @@ if (figma.command == 'dark') {
             }
 
             var allStyles = [...localStyles, ...importStyles]
+            allStyles = allStyles.filter((style) => style !== undefined);
+
             // console.log(allStyles)
 
             //Creating style couples

--- a/code.js
+++ b/code.js
@@ -277,6 +277,7 @@ if (figma.command == 'light') {
 
             var allStyles = [...localStyles, ...importStyles]
             // console.log(allStyles)
+            allStyles = allStyles.filter((style) => style !== undefined);            
 
             //Creating style couples
             for (let paintStyle of allStyles) {


### PR DESCRIPTION
I was running into a problem where running the extension in a file using an external style library was hanging. I don't know how common this is, but I noticed a bunch of 404s in the console:

<img width="523" alt="CleanShot 2021-06-11 at 09 30 40@2x" src="https://user-images.githubusercontent.com/6104/121694037-b6c26e00-ca97-11eb-9fa5-bc8e82f4ecb5.png">

Debugging the extension, I found that some of the styles in the `allStyles` array were `undefined` (perhaps related to the 404s?). Filtering these out before iterating fixed my problem so I thought I'd propose this change.