### PR TITLE
Fix objectLocal lookups

### DIFF
--- a/code.js
+++ b/code.js
@@ -197,21 +197,25 @@ if (figma.command == 'dark') {
                 frame.strokeStyleId = object[frame.strokeStyleId];
                 counter++;
             }
-            if (frame.fillStyleId && objectLocal && objectLocal[frame.fillStyleId]) {
-                frame.fillStyleId = objectLocal[frame.fillStyleId];
+            if (
+                frame.effectStyleId &&
+                objectLocal &&
+                objectLocal[frame.effectStyleId.slice(0, 43)]
+            ) {
+                frame.effectStyleId = objectLocal[frame.effectStyleId.slice(0, 43)];
                 counter++;
             }
-            if (frame.effectStyleId && objectLocal && objectLocal[frame.effectStyleId]) {
-                frame.effectStyleId = objectLocal[frame.effectStyleId];
-                counter++;
-            }
-            if (frame.strokeStyleId && objectLocal && objectLocal[frame.strokeStyleId]) {
-                frame.strokeStyleId = objectLocal[frame.strokeStyleId];
-                counter++;
+            if (
+                frame.strokeStyleId &&
+                objectLocal &&
+                objectLocal[frame.strokeStyleId.slice(0, 43)]
+            ) {
+                frame.strokeStyleId = objectLocal[frame.strokeStyleId.slice(0, 43)];
+                counter++;      
             }
         }
     }
-//Checking day colors
+    //Checking day colors
     function notDayObjects() {
         if (counter == 0) {
             figma.closePlugin(`😶 Selection does not have style pairs`);
@@ -329,17 +333,21 @@ if (figma.command == 'light') {
                 frame.strokeStyleId = object[frame.strokeStyleId];
                 counter++
             }
-            if (frame.fillStyleId && objectLocal && objectLocal[frame.fillStyleId]) {
-                frame.fillStyleId = objectLocal[frame.fillStyleId];
-                counter++
-            }
-            if (frame.effectStyleId && objectLocal && objectLocal[frame.effectStyleId]) {
-                frame.effectStyleId = objectLocal[frame.effectStyleId];
+            if (
+                frame.effectStyleId &&
+                objectLocal &&
+                objectLocal[frame.effectStyleId.slice(0, 43)]
+            ) {
+                frame.effectStyleId = objectLocal[frame.effectStyleId.slice(0, 43)];
                 counter++;
             }
-            if (frame.strokeStyleId && objectLocal && objectLocal[frame.strokeStyleId]) {
-                frame.strokeStyleId = objectLocal[frame.strokeStyleId];
-                counter++
+            if (
+                frame.strokeStyleId &&
+                objectLocal &&
+                objectLocal[frame.strokeStyleId.slice(0, 43)]
+            ) {
+                frame.strokeStyleId = objectLocal[frame.strokeStyleId.slice(0, 43)];
+                counter++;      
             }
         }
     }


### PR DESCRIPTION
After further debugging my issues, I found the bug. The keys for `objectLocal` are all the shorter versions without the trailing comma values as set here with the `slice`:

https://github.com/glmrvn/Appearance-figma-plugin/blob/fa2589403aea2a4dbd9ac31ee2379747ded9838e/code.js#L167-L169

On subsequent lookups, the extension is looking for style matches using the full string and not the sliced version. Doing the same slice on those values fixes the problem